### PR TITLE
feat: add verify token forget password endpoint and swagger docs

### DIFF
--- a/backend/src/modules/auth/auth.controller.js
+++ b/backend/src/modules/auth/auth.controller.js
@@ -71,8 +71,28 @@ const forgetPassword = async (req, res, next) => {
   }
 };
 
+const verifyForgetPasswordToken = async (req, res, next) => {
+  try {
+    const result = authValidation.verifiTokenSchema.safeParse(req.body);
+    if (!result.success) {
+      return next(ApiError.validation('Validation failed', result.error));
+    }
+
+    const data = await authService.verifyForgetPasswordToken(result.data.token);
+
+    return res.status(STATUS_CODES.OK).json({
+      success: true,
+      message: ' Forget password token is valid',
+      data: data
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 module.exports = {
   forgetPassword,
   login,
-  register
+  register,
+  verifyForgetPasswordToken
 };

--- a/backend/src/modules/auth/auth.controller.js
+++ b/backend/src/modules/auth/auth.controller.js
@@ -71,7 +71,6 @@ const forgetPassword = async (req, res, next) => {
   }
 };
 
-
 const verifyForgetPasswordToken = async (req, res, next) => {
   try {
     const result = authValidation.verifiTokenSchema.safeParse(req.body);

--- a/backend/src/modules/auth/auth.router.js
+++ b/backend/src/modules/auth/auth.router.js
@@ -5,5 +5,6 @@ const router = express.Router();
 
 router.post('/login', authController.login);
 router.post('/register', authController.register);
+router.post('/forget-password', authController.verifyForgetPasswordToken);
 
 module.exports = router;

--- a/backend/src/modules/auth/auth.service.js
+++ b/backend/src/modules/auth/auth.service.js
@@ -175,7 +175,7 @@ const verifyForgetPasswordToken = async token => {
     user_id: userToken.userId,
     type: userToken.type,
     expires_at: userToken.expiresAt
-   };
+  };
 };
 
 /**

--- a/backend/src/modules/auth/auth.service.js
+++ b/backend/src/modules/auth/auth.service.js
@@ -141,8 +141,38 @@ const forgetPassword = async email => {
   });
 };
 
+const verifyForgetPasswordToken = async token => {
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+
+  const userToken = await prisma.userToken.findFirst({
+    where: {
+      tokenHash: tokenHash,
+      type: 'PASSWORD_RESET'
+    }
+  });
+
+  if (!userToken) {
+    throw new Error('Invalid token');
+  }
+
+  if (userToken.isUsed) {
+    throw new Error('Token has already been used');
+  }
+
+  if (new Date() > new Date(userToken.expiresAt)) {
+    throw new Error('Token has expired');
+  }
+
+  return {
+    user_id: userToken.userId,
+    type: userToken.type,
+    expires_at: userToken.expiresAt
+  };
+};
+
 module.exports = {
   login,
   register,
-  forgetPassword
+  forgetPassword,
+  verifyForgetPasswordToken
 };

--- a/backend/src/modules/auth/auth.validation.js
+++ b/backend/src/modules/auth/auth.validation.js
@@ -62,8 +62,17 @@ const registerSchema = z.object({
     .min(MIN_PASSWORD_LENGTH, 'Password must be at least 6 characters')
 });
 
+const verifiTokenSchema = z.object({
+  token: z
+    .string({
+      required_error: 'Token is required'
+    })
+    .min(1, 'Token cannot be empty')
+});
+
 module.exports = {
   loginSchema,
   registerSchema,
-  forgetPasswordSchema
+  forgetPasswordSchema,
+  verifiTokenSchema
 };

--- a/docs/schemas/auth.yaml
+++ b/docs/schemas/auth.yaml
@@ -72,3 +72,64 @@ components:
           format: email
           description: Email terdaftar untuk reset password
           example: "john@example.com"
+
+paths:
+  /api/auth/forget-password/verify-token:
+    post:
+      tags:
+        - Auth
+      summary: Verifikasi token forget password
+      description: Mengecek apakah token reset password valid, belum digunakan, dan belum kadaluarsa.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - token
+              properties:
+                token:
+                  type: string
+                  description: Token raw yang didapat user dari email
+                  example: "abc123randomstring"
+      responses:
+        "200":
+          description: Token valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: "Forget password token is valid"
+                  data:
+                    type: object
+                    properties:
+                      user_id:
+                        type: string
+                        example: "00000000-0000-0000-0000-000000000001"
+                      type:
+                        type: string
+                        example: "PASSWORD_RESET"
+                      expires_at:
+                        type: string
+                        format: date-time
+                        example: "2026-04-02T10:00:00.000Z"
+        "400":
+          description: Bad Request (Input token tidak valid/kosong)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized (Token tidak valid, sudah kadaluarsa, atau sudah digunakan)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"


### PR DESCRIPTION
## Description
Membuat endpoint `POST /api/auth/forget-password/verify-token` untuk memvalidasi token sebelum user melakukan reset password. 
Perubahan yang dilakukan meliputi:
- Menambahkan validasi request body menggunakan Zod (wajib mengirimkan `token`).
- Mengubah input token menjadi hash SHA-256 dan mencocokkannya ke tabel `user_tokens`.
- Menambahkan validasi pengecekan status token (apakah `type=PASSWORD_RESET`, `isUsed=false`, dan `expiresAt > now`).
- Memperbarui dokumentasi OpenAPI/Swagger di `docs/schemas/auth.yaml` agar sinkron dengan endpoint baru.

## Related Issue
<!-- Link ke issue terkait: closes #xxx -->
Task terkait: [Trello / Ticket Link]

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] DevOps / CI/CD
- [ ] AI / Model update

## Area Affected
- [ ] Frontend
- [x] Backend
- [ ] AI / Data Science
- [x] Database
- [ ] Infrastructure

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented)

## Screenshots (if applicable)